### PR TITLE
add player-aware tooltips and hotbar slot validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.github.darksoulq'
-version = '1.7.2-mc1.21.9'
+version = '1.7.3-mc1.21.9'
 
 def targetJavaVersion = 21
 

--- a/src/main/java/com/github/darksoulq/abyssallib/server/event/internal/ItemEvents.java
+++ b/src/main/java/com/github/darksoulq/abyssallib/server/event/internal/ItemEvents.java
@@ -169,7 +169,7 @@ public class ItemEvents {
         if (!(event.getClickedInventory() instanceof PlayerInventory pInv)) return;
         if (event.getClick().isKeyboardClick()) {
             int hotbarSlot = event.getHotbarButton();
-            if (hotbarSlot >= 0 && hotbarSlot <= 8) {
+            if (hotbarSlot != -1) {
                 Item item = Item.resolve(event.getClickedInventory().getItem(hotbarSlot));
                 if (item != null
                         && item.onClickInInventory((Player) event.getWhoClicked(), hotbarSlot, pInv, InventoryClickType.of(event.getClick())) == ActionResult.CANCEL) event.setCancelled(true);

--- a/src/main/java/com/github/darksoulq/abyssallib/server/event/internal/ItemEvents.java
+++ b/src/main/java/com/github/darksoulq/abyssallib/server/event/internal/ItemEvents.java
@@ -169,9 +169,11 @@ public class ItemEvents {
         if (!(event.getClickedInventory() instanceof PlayerInventory pInv)) return;
         if (event.getClick().isKeyboardClick()) {
             int hotbarSlot = event.getHotbarButton();
-            Item item = Item.resolve(event.getClickedInventory().getItem(hotbarSlot));
-            if (item != null
-                && item.onClickInInventory((Player) event.getWhoClicked(), hotbarSlot, pInv, InventoryClickType.of(event.getClick())) == ActionResult.CANCEL) event.setCancelled(true);
+            if (hotbarSlot >= 0 && hotbarSlot <= 8) {
+                Item item = Item.resolve(event.getClickedInventory().getItem(hotbarSlot));
+                if (item != null
+                        && item.onClickInInventory((Player) event.getWhoClicked(), hotbarSlot, pInv, InventoryClickType.of(event.getClick())) == ActionResult.CANCEL) event.setCancelled(true);
+            }
         }
         Item item = Item.resolve(event.getCurrentItem());
         if (item == null) return;

--- a/src/main/java/com/github/darksoulq/abyssallib/world/item/Item.java
+++ b/src/main/java/com/github/darksoulq/abyssallib/world/item/Item.java
@@ -54,12 +54,12 @@ public class Item implements Cloneable {
         setData(new ItemName(Component.translatable("item." + id.getNamespace() + "." + id.getPath())));
         setData(new ItemModel(id.asNamespacedKey()));
         setData(new CustomMarker(id));
-        createTooltip(tooltip, null);
-        updateTooltip();
     }
 
     public void createTooltip(Tooltip tooltip) {}
-    public void createTooltip(Tooltip tooltip, @Nullable Player player) {}
+    public void createTooltip(Tooltip tooltip, @Nullable Player player) {
+        createTooltip(tooltip);
+    }
     public void updateTooltip() {
         setData(new Lore(ItemLore.lore(tooltip.lines)));
         setData(new DisplayTooltip(TooltipDisplay.tooltipDisplay()
@@ -138,15 +138,18 @@ public class Item implements Cloneable {
     public Identifier getId() {
         return id;
     }
-    public ItemStack getStack() {
+    public ItemStack getRawStack() {
         return stack;
+    }
+    public ItemStack getStack() {
+        return getStack(null);
     }
     public ItemStack getStack(@Nullable Player player) {
         Item contextItem = this.clone();
         contextItem.tooltip.lines.clear();
         contextItem.createTooltip(contextItem.tooltip, player);
         contextItem.updateTooltip();
-        return contextItem.getStack();
+        return contextItem.getRawStack();
     }
     public ComponentMap getComponentMap() {
         return componentMap;

--- a/src/main/java/com/github/darksoulq/abyssallib/world/item/Item.java
+++ b/src/main/java/com/github/darksoulq/abyssallib/world/item/Item.java
@@ -54,9 +54,12 @@ public class Item implements Cloneable {
         setData(new ItemName(Component.translatable("item." + id.getNamespace() + "." + id.getPath())));
         setData(new ItemModel(id.asNamespacedKey()));
         setData(new CustomMarker(id));
+        createTooltip(tooltip, null);
+        updateTooltip();
     }
 
     public void createTooltip(Tooltip tooltip) {}
+    public void createTooltip(Tooltip tooltip, @Nullable Player player) {}
     public void updateTooltip() {
         setData(new Lore(ItemLore.lore(tooltip.lines)));
         setData(new DisplayTooltip(TooltipDisplay.tooltipDisplay()
@@ -137,6 +140,13 @@ public class Item implements Cloneable {
     }
     public ItemStack getStack() {
         return stack;
+    }
+    public ItemStack getStack(@Nullable Player player) {
+        Item contextItem = this.clone();
+        contextItem.tooltip.lines.clear();
+        contextItem.createTooltip(contextItem.tooltip, player);
+        contextItem.updateTooltip();
+        return contextItem.getStack();
     }
     public ComponentMap getComponentMap() {
         return componentMap;

--- a/src/main/java/com/github/darksoulq/abyssallib/world/item/component/ComponentMap.java
+++ b/src/main/java/com/github/darksoulq/abyssallib/world/item/component/ComponentMap.java
@@ -45,15 +45,15 @@ public class ComponentMap {
         if (this.entity != null) loadEntity();
     }
     public void loadItem() {
-        if (item == null || item.getStack() == null) return;
+        if (item == null || item.getRawStack() == null) return;
 
-        for (DataComponentType type : item.getStack().getDataTypes()) {
+        for (DataComponentType type : item.getRawStack().getDataTypes()) {
             Class<? extends DataComponent<?>> cls = Registries.DATA_COMPONENTS.get(type.key().toString());
             if (cls == null) continue;
 
             try {
                 if (type instanceof DataComponentType.Valued<?> vl) {
-                    Object val = item.getStack().getData(vl);
+                    Object val = item.getRawStack().getData(vl);
                     if (val == null) continue;
                     Constructor<?> cons = Arrays.stream(cls.getConstructors())
                             .filter(c -> c.getParameterCount() == 1 &&
@@ -88,7 +88,7 @@ public class ComponentMap {
     public void removeData(Identifier id) {
         if (vanillaComponents.containsKey(id)) {
             Vanilla v = vanillaComponents.remove(id);
-            if (item != null) v.remove(item.getStack());
+            if (item != null) v.remove(item.getRawStack());
         }
         else if (components.containsKey(id)) {
             removeComponent(components.get(id));
@@ -101,7 +101,7 @@ public class ComponentMap {
         for (Vanilla v : vanillaComponents.values()) {
             if (clazz.isInstance(v)) {
                 vanillaComponents.remove(((DataComponent<?>) v).getId());
-                if (item != null) v.remove(item.getStack());
+                if (item != null) v.remove(item.getRawStack());
             }
         }
     }
@@ -137,7 +137,7 @@ public class ComponentMap {
         }
         if (item != null) {
             for (Vanilla v : vanillaComponents.values()) {
-                v.apply(item.getStack());
+                v.apply(item.getRawStack());
             }
         }
         rootTag.put("CustomComponents", data.toVanilla());

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,5 +1,5 @@
 name: AbyssalLib
-version: '1.7.2-mc1.21.9'
+version: '1.7.3-mc1.21.9'
 main: com.github.darksoulq.abyssallib.AbyssalLib
 api-version: '1.21'
 authors: [ DarkSoul ]


### PR DESCRIPTION
Changes:
1. Added the ability to pass a Player when creating an ItemStack:
    - Item.getStack(Player) now allows generating tooltips with content specific to the player.
    - This enables displaying personalized data.

Example usage:
Kotlin:
```kt
class ExamplePlayerStatsItem(id: Identifier) : Item(id, Material.PAPER) { 
    init {
        createTooltip(tooltip)
        updateTooltip()
    }

    override fun createTooltip(tooltip: Tooltip, player: Player?) {
        tooltip.lines.clear() 
        tooltip.addLine(Component.text("Player stats:")) 
        if (player != null) {
            tooltip.addLine(Component.text("NickName: ${player.name}")) 
            tooltip.addLine(Component.text("XP: ${player.totalExperience}"))
            tooltip.addLine(Component.text("Ping: ${player.ping} ms"))
        } else {
            tooltip.addLine(Component.text("<data is not loaded>")) 
        }
    }
}
```

2. Added validation for hotbarSlot in onClickInInventory:
    - Previously, getHotbarButton() could return -1, causing errors.
    - Now the slot is checked to be within the range 0–8 before processing.

Why this is needed:
    - Enables dynamic, player-specific tooltips.
    - Prevents issues with invalid hotbar slots.